### PR TITLE
Add missing "tags" value to tag-escaping docs

### DIFF
--- a/tags/tag-basics/tag-escaping.md
+++ b/tags/tag-basics/tag-escaping.md
@@ -56,6 +56,9 @@ Will output:
 `escape="tidy, textile"`
 : Remove spaces/newlines, prepend a single space to remove the surrounding `<p>` tag, then Textile the content.
 
+`escape="tags"`
+: Strips all HTML tags and comments from the content leaving you with just the text/data of the content.
+
 `escape="some-tag"`
 : Strip any self-closing `<some-tag />`, or unwrap any container `<some-tag>...</some-tag>` in the content.
 


### PR DESCRIPTION
Already exists in the code (it applies PHP "strip_tags") but is missing from the docs. 

Nice, because it means you can do without etz_striptags.