### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/development/contributing.md
+++ b/development/contributing.md
@@ -46,7 +46,7 @@ The general steps for Pull Requests:
 
 ### Coding standard
 
-The project follows the [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide-meta.md) standards with PHP 5.3 style namespacing. You can use [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to make sure your additions follow them, too:
+The project follows the [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide-meta.md) standards with PHP 5.3 style namespacing. You can use [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) to make sure your additions follow them, too:
 
 ~~~ bash
 $ ./vendor/bin/phpcs --standard=phpcs.xml *.php textpattern


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932